### PR TITLE
Correct Destination in traffic view detail page

### DIFF
--- a/app-shared/lib/pages/monitoring/traffic_view_detail.dart
+++ b/app-shared/lib/pages/monitoring/traffic_view_detail.dart
@@ -60,7 +60,7 @@ class _TrafficViewDetailState extends State<TrafficViewDetail> {
                 SizedBox(height: 2),
                 Text(s.sourcePort+": ${flow.src_port}", style: protStyle),
                 SizedBox(height: 2),
-                Text(s.destinationPort+": ${flow.dst_addr}", style: protStyle),
+                Text(s.destination+": ${flow.dst_addr}", style: protStyle),
                 SizedBox(height: 2),
                 Text(s.destinationPort+": ${flow.dst_port}", style: protStyle),
               ],


### PR DESCRIPTION
The Connection Detail page in the traffic view showeed
both the destination address and destination port with
the destinationPort label.  This corrects that.